### PR TITLE
Revert "fix tests"

### DIFF
--- a/flexbe_testing/package.xml
+++ b/flexbe_testing/package.xml
@@ -22,7 +22,6 @@
 
   <exec_depend>flexbe_core</exec_depend>
   <exec_depend>flexbe_msgs</exec_depend>
-  <exec_depend>flexbe_states</exec_depend>
   <exec_depend>rospy</exec_depend>
 
   <test_depend>rosunit</test_depend>


### PR DESCRIPTION
Reverts mojin-robotics/flexbe_behavior_engine#8

because it introduced a cyclic dependency
should be properly resolved as tracked in #9 