### PR TITLE
Fix Preempted Concurrency

### DIFF
--- a/flexbe_core/src/flexbe_core/core/concurrency_container.py
+++ b/flexbe_core/src/flexbe_core/core/concurrency_container.py
@@ -74,7 +74,7 @@ class ConcurrencyContainer(OperatableStateMachine):
             return None
 
         # trigger on_exit for those states that are not done yet
-        self.on_exit(self.userdata,
+        self.on_exit(self._userdata,
                      states=[s for s in self._states if (s.name not in list(self._returned_outcomes.keys()) or
                                                          self._returned_outcomes[s.name] is None)])
         self._returned_outcomes = dict()

--- a/flexbe_core/src/flexbe_core/core/concurrency_container.py
+++ b/flexbe_core/src/flexbe_core/core/concurrency_container.py
@@ -62,6 +62,8 @@ class ConcurrencyContainer(OperatableStateMachine):
         outcome = None
         if any(self._returned_outcomes[state.name] == state._preempted_name
                for state in self._states if state.name in self._returned_outcomes):
+            self._returned_outcomes = dict()
+            self._current_state = None
             return self._preempted_name  # handle preemption if required
         # check conditions
         for item in self._conditions:
@@ -119,3 +121,5 @@ class ConcurrencyContainer(OperatableStateMachine):
             if state in self._returned_outcomes:
                 continue  # skip states that already exited themselves
             self._execute_single_state(state, force_exit=True)
+        self._returned_outcomes = dict()
+        self._current_state = None

--- a/flexbe_core/src/flexbe_core/core/operatable_state_machine.py
+++ b/flexbe_core/src/flexbe_core/core/operatable_state_machine.py
@@ -222,7 +222,7 @@ class OperatableStateMachine(PreemptableStateMachine):
 
     def on_exit(self, userdata):
         if self._current_state is not None:
-            ud = UserData(reference=self.userdata, input_keys=self._current_state.input_keys,
+            ud = UserData(reference=self._userdata, input_keys=self._current_state.input_keys,
                           output_keys=self._current_state.output_keys,
                           remap=self._remappings[self._current_state.name])
             self._current_state._entering = True


### PR DESCRIPTION
Preempting a running concurrency container leads to wrong userdata values on the next enter. Resetting the member variables `_current_state` and `_returned_outcomes` on exit and preemption fixes this.